### PR TITLE
Ignore non-markdown files

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -23,6 +23,11 @@ const stripFrontmatter = (body, fm) => {
 	return body.replace(`---\n${fm.frontmatter}\n---\n\n`, '');
 };
 
+const isMarkdownFile = file => {
+	const ext = path.extname(file).toLowerCase();
+	return ext === '.md' || ext === '.markdown';
+};
+
 class Store {
 	constructor(documentsPath) {
 		this.documentsPath = documentsPath;
@@ -32,7 +37,7 @@ class Store {
 
 	async getDocuments() {
 		const dir = await fs.readdir(this.documentsPath);
-		const files = dir.map(file => path.join(this.documentsPath, file));
+		const files = dir.filter(isMarkdownFile).map(file => path.join(this.documentsPath, file));
 
 		const docs = await map(files, async filePath => {
 			const filename = path.basename(filePath);


### PR DESCRIPTION
This patch filters-out non-Markdown files (for example, `.gitkeep`) in your document path.