### PR TITLE
Fetch documents by category

### DIFF
--- a/resolvers/Query.js
+++ b/resolvers/Query.js
@@ -3,8 +3,11 @@ const slugify = require('slugg');
 
 const DEFAULT_LIMIT = 10;
 
-exports.documents = async (root, {skip, limit}, {store}) => {
-	const docs = await store.getDocuments();
+exports.documents = async (root, {skip, limit, category}, {store}) => {
+	let docs = await store.getDocuments();
+	if (category) {
+		docs = docs.filter(doc => doc.frontmatter.category === category);
+	}
 
 	if (typeof skip === 'number') {
 		return docs.slice(skip, limit || DEFAULT_LIMIT);
@@ -30,9 +33,4 @@ exports.categories = async (root, params, {store}) => {
 	const uniqueCategories = new Set([...categories]);
 
 	return [...uniqueCategories];
-};
-
-exports.category = async (root, {name}, {store}) => {
-	const docs = await store.getDocuments();
-	return docs.filter(doc => doc.frontmatter.category === name);
 };

--- a/resolvers/Query.js
+++ b/resolvers/Query.js
@@ -31,3 +31,8 @@ exports.categories = async (root, params, {store}) => {
 
 	return [...uniqueCategories];
 };
+
+exports.category = async (root, {name}, {store}) => {
+	const docs = await store.getDocuments();
+	return docs.filter(doc => doc.frontmatter.category === name);
+};

--- a/schema.graphql
+++ b/schema.graphql
@@ -20,8 +20,6 @@ type Query {
 	documents(skip: Int, limit: Int, category: String): [Document!]!
 	document(slug: String!): Document
 	categories: [String!]
-	# Return all documents of category `name`.
-	category(name: String!): [Document!]
 }
 
 schema {

--- a/schema.graphql
+++ b/schema.graphql
@@ -17,7 +17,7 @@ type Document {
 }
 
 type Query {
-	documents(skip: Int, limit: Int): [Document!]!
+	documents(skip: Int, limit: Int, category: String): [Document!]!
 	document(slug: String!): Document
 	categories: [String!]
 	# Return all documents of category `name`.

--- a/schema.graphql
+++ b/schema.graphql
@@ -20,6 +20,8 @@ type Query {
 	documents(skip: Int, limit: Int): [Document!]!
 	document(slug: String!): Document
 	categories: [String!]
+	# Return all documents of category `name`.
+	category(name: String!): [Document!]
 }
 
 schema {

--- a/test/test.js
+++ b/test/test.js
@@ -176,3 +176,33 @@ test('fetch categories', async t => {
 
 	t.deepEqual(body.categories, ['Announcements', 'News']);
 });
+
+test('fetch documents by category', async t => {
+	const server = await listen(createServer(documentsPath));
+	const {body} = await graphqlGot(server, {
+		query: `
+				query {
+					category(name: "News") {
+						title
+					}
+				}
+			`
+	});
+
+	t.deepEqual(body.category, [{title: 'First'}]);
+});
+
+test('fetch documents with missing category', async t => {
+	const server = await listen(createServer(documentsPath));
+	const {body} = await graphqlGot(server, {
+		query: `
+				query {
+					category(name: "Missing") {
+						title
+					}
+				}
+			`
+	});
+
+	t.deepEqual(body.category, []);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -182,14 +182,14 @@ test('fetch documents by category', async t => {
 	const {body} = await graphqlGot(server, {
 		query: `
 				query {
-					category(name: "News") {
+					documents(category: "News") {
 						title
 					}
 				}
 			`
 	});
 
-	t.deepEqual(body.category, [{title: 'First'}]);
+	t.deepEqual(body.documents, [{title: 'First'}]);
 });
 
 test('fetch documents with missing category', async t => {
@@ -197,12 +197,12 @@ test('fetch documents with missing category', async t => {
 	const {body} = await graphqlGot(server, {
 		query: `
 				query {
-					category(name: "Missing") {
+					documents(category: "Missing") {
 						title
 					}
 				}
 			`
 	});
 
-	t.deepEqual(body.category, []);
+	t.deepEqual(body.documents, []);
 });


### PR DESCRIPTION
This patch adds an additional field to the `documents()` query, which enables you to fetch all documents by category.

Arguably, this could be done client-side, but I've got many documents and don't want to load all of them into the browser's memory if I don't have to. 😉 